### PR TITLE
Fix label accumulation across issue sections when using --auto-label

### DIFF
--- a/ietf_comments/ui.py
+++ b/ietf_comments/ui.py
@@ -93,7 +93,7 @@ def ietf_comments_cli() -> None:
     for issue_type in comments.sections:
         these_comments = comments.issues[issue_type]
         if args.github_repo:
-            labels = args.github_label or []
+            labels = list(args.github_label or [])
             if args.auto_label:
                 labels.extend(["review", issue_type])
             create_issues(


### PR DESCRIPTION
args.github_label is a list built by argparse (action="append"). The assignment made labels an alias for the same list object rather than a copy, so labels.extend(...) mutated args.github_label in place. On each subsequent iteration the already-mutated list was reused, causing labels to accumulate — e.g. a "comment" issue would end up labeled ["ad-review", "review", "discuss", "review", "comment"] instead of ["ad-review", "review", "comment"].

Fix
Changed labels = args.github_label or [] to labels = list(args.github_label or []) so each iteration gets a fresh copy.

Fixes #21.